### PR TITLE
Enabled gzip dynamic content compression

### DIFF
--- a/build/applicationHost.xdt
+++ b/build/applicationHost.xdt
@@ -5,7 +5,7 @@
       <scheme name="br" xdt:Locator="Match(name)" xdt:Transform="Remove" />
       <scheme name="gzip" xdt:Locator="Match(name)" xdt:Transform="Remove" />
       <scheme name="br" dll="%XDT_EXTENSIONPATH%\%XDT_BITNESS%\iisbrotli.dll" xdt:Transform="Insert" xdt:Locator="Match(name)" />
-      <scheme name="gzip" dll="%XDT_EXTENSIONPATH%\%XDT_BITNESS%\iiszlib.dll" xdt:Transform="Insert" xdt:Locator="Match(name)" />
+      <scheme name="gzip" dll="%XDT_EXTENSIONPATH%\%XDT_BITNESS%\iiszlib.dll" dynamicCompressionLevel="1" xdt:Transform="Insert" xdt:Locator="Match(name)" />
     </httpCompression>
     <rewrite>
       <allowedServerVariables>


### PR DESCRIPTION
>Level 0 of iiszlib.dll specifies no compression rather than best-speed compression. The default IIS dynamicCompressionLevel attribute value in the <httpCompression> element is 0 as well. Therefore, dynamicCompressionLevel needs to be explicitly set above 0 to allow iiszlib.dll to compress dynamically generated contents.

https://docs.microsoft.com/en-us/iis/extensions/iis-compression/using-iis-compression